### PR TITLE
Add timeout flag if appext.BuilderWithTimeout is called with 0

### DIFF
--- a/appext/appext.go
+++ b/appext/appext.go
@@ -130,10 +130,22 @@ func NewBuilder(appName string, options ...BuilderOption) Builder {
 // BuilderOption is an option for a new Builder.
 type BuilderOption func(*builder)
 
-// BuilderWithTimeout returns a new BuilderOption that adds a timeout flag and the default timeout.
+// BuilderWithTimeout returns a new BuilderOption that adds a timeout flag with the default timeout.
+//
+// If defaultTimeout is 0, this has no effect. Use BuilderWithTimeoutFlag to add a timeout flag
+// with the default being 0.
 func BuilderWithTimeout(defaultTimeout time.Duration) BuilderOption {
 	return func(builder *builder) {
 		builder.defaultTimeout = defaultTimeout
+	}
+}
+
+// BuilderWithTimeoutFlag returns a new BuilderOption that adds a timeout flag.
+//
+// Calling BuilderWithTimeout with a non-zero timeout implicitly calls BuilderWithTimeoutFlag.
+func BuilderWithTimeoutFlag() BuilderOption {
+	return func(builder *builder) {
+		builder.timeoutFlag = true
 	}
 }
 

--- a/appext/appext.go
+++ b/appext/appext.go
@@ -132,20 +132,10 @@ type BuilderOption func(*builder)
 
 // BuilderWithTimeout returns a new BuilderOption that adds a timeout flag with the default timeout.
 //
-// If defaultTimeout is 0, this has no effect. Use BuilderWithTimeoutFlag to add a timeout flag
-// with the default being 0.
+// If defaultTimeout is 0, no timeout will be used by default, but the flag will exist.
 func BuilderWithTimeout(defaultTimeout time.Duration) BuilderOption {
 	return func(builder *builder) {
 		builder.defaultTimeout = defaultTimeout
-		builder.timeoutFlag = true
-	}
-}
-
-// BuilderWithTimeoutFlag returns a new BuilderOption that adds a timeout flag.
-//
-// Calling BuilderWithTimeout with a non-zero timeout implicitly calls BuilderWithTimeoutFlag.
-func BuilderWithTimeoutFlag() BuilderOption {
-	return func(builder *builder) {
 		builder.timeoutFlag = true
 	}
 }

--- a/appext/appext.go
+++ b/appext/appext.go
@@ -137,6 +137,7 @@ type BuilderOption func(*builder)
 func BuilderWithTimeout(defaultTimeout time.Duration) BuilderOption {
 	return func(builder *builder) {
 		builder.defaultTimeout = defaultTimeout
+		builder.timeoutFlag = true
 	}
 }
 

--- a/appext/builder.go
+++ b/appext/builder.go
@@ -35,6 +35,7 @@ type builder struct {
 	timeout time.Duration
 
 	defaultTimeout time.Duration
+	timeoutFlag    bool
 
 	interceptors   []Interceptor
 	loggerProvider LoggerProvider
@@ -54,8 +55,8 @@ func newBuilder(appName string, options ...BuilderOption) *builder {
 func (b *builder) BindRoot(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&b.debug, "debug", false, "Turn on debug logging")
 	flagSet.StringVar(&b.logFormat, "log-format", "color", "The log format [text,color,json]")
-	if b.defaultTimeout > 0 {
-		flagSet.DurationVar(&b.timeout, "timeout", b.defaultTimeout, `The duration until timing out, setting it to zero means no timeout`)
+	if b.defaultTimeout > 0 || b.timeoutFlag {
+		flagSet.DurationVar(&b.timeout, "timeout", b.defaultTimeout, `The duration until timing out, setting it to 0 means no timeout`)
 	}
 
 	// We do not officially support this flag, this is for testing, where we need warnings turned off.

--- a/appext/builder.go
+++ b/appext/builder.go
@@ -55,7 +55,7 @@ func newBuilder(appName string, options ...BuilderOption) *builder {
 func (b *builder) BindRoot(flagSet *pflag.FlagSet) {
 	flagSet.BoolVar(&b.debug, "debug", false, "Turn on debug logging")
 	flagSet.StringVar(&b.logFormat, "log-format", "color", "The log format [text,color,json]")
-	if b.defaultTimeout > 0 || b.timeoutFlag {
+	if b.timeoutFlag {
 		flagSet.DurationVar(&b.timeout, "timeout", b.defaultTimeout, `The duration until timing out, setting it to 0 means no timeout`)
 	}
 


### PR DESCRIPTION
An alternative strategy to https://github.com/bufbuild/buf/pull/4089. This allows adding a `--timeout` flag with 0 as the default value.