### PR TITLE
Upgrade repository

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [1.23.x, 1.24.x]
+        go-version:
+        - name: latest
+          version: 1.26.x
+        - name: previous
+          version: 1.25.x
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
@@ -23,7 +27,7 @@ jobs:
       - name: Install Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: ${{ matrix.go-version.version }}
       - name: Test
         run: make test
       - name: Lint
@@ -31,5 +35,5 @@ jobs:
         # conflicting guidance, run only on the most recent supported version.
         # For the same reason, only check generated code on the most recent
         # supported version.
-        if: matrix.go-version == '1.24.x'
+        if: matrix.go-version.name == 'latest'
         run: make checkgenerate && make lint

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,7 +4,6 @@ on:
     branches: [main]
     tags: ['v*']
   pull_request:
-    branches: [main]
   schedule:
     - cron: '15 22 * * *'
   workflow_dispatch: {} # support manual runs

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,25 +1,6 @@
-linters-settings:
-  errcheck:
-    check-type-assertions: true
-  forbidigo:
-    forbid:
-      - '^fmt\.Print'
-      - '^log\.'
-      - '^print$'
-      - '^println$'
-      - '^panic$'
-  godox:
-    # TODO, OPT, etc. comments are fine to commit. Use FIXME comments for
-    # temporary hacks, and use godox to prevent committing them.
-    keywords: [FIXME]
-  varnamelen:
-    ignore-decls:
-      - T any
-      - i int
-      - wg sync.WaitGroup
-      - id string
+version: "2"
 linters:
-  enable-all: true
+  default: all
   disable:
     - cyclop            # covered by gocyclo
     - depguard          # unnecessary for small libraries
@@ -28,8 +9,6 @@ linters:
     - funlen            # rely on code review to limit function length
     - gochecknoglobals  # many exceptions
     - gocognit          # dubious "cognitive overhead" quantification
-    - gofumpt           # prefer standard gofmt
-    - goimports         # rely on gci instead
     - inamedparam       # not standard style
     - interfacebloat    # many exceptions
     - ireturn           # "accept interfaces, return structs" isn't ironclad
@@ -43,25 +22,60 @@ linters:
     - thelper           # we want to print out the whole stack
     - wrapcheck         # don't _always_ need to wrap errors
     - wsl               # generous whitespace violates house style
-issues:
-  exclude-dirs-use-default: false
-  exclude-rules:
-    - linters:
-        - revive
-      text: "error.*capitalized"
-    - linters:
-        - stylecheck
-      text: "error.*capitalized"
-    - linters:
-        - stylecheck
-      path: appcmd/appcmd.go
-      text: "ST1005"
-    - linters:
-        - unparam
-      path: appext/name_container_unix_test.go
-    - linters:
-        - varnamelen
-      path: app.go
-    - linters:
-        - varnamelen
-      path: appext/builder.go
+    - noinlineerr       # if err := ...; err != nil is idiomatic Go
+    - wsl_v5            # generous whitespace violates house style
+  settings:
+    errcheck:
+      check-type-assertions: true
+    forbidigo:
+      forbid:
+        - pattern: '^fmt\.Print'
+        - pattern: '^log\.'
+        - pattern: '^print$'
+        - pattern: '^println$'
+        - pattern: '^panic$'
+    godox:
+      # TODO, OPT, etc. comments are fine to commit. Use FIXME comments for
+      # temporary hacks, and use godox to prevent committing them.
+      keywords: [FIXME]
+    varnamelen:
+      ignore-decls:
+        - T any
+        - i int
+        - wg sync.WaitGroup
+        - id string
+  exclusions:
+    rules:
+      - linters:
+          - revive
+        text: "error.*capitalized"
+      - linters:
+          - staticcheck
+        text: "error.*capitalized"
+      - linters:
+          - staticcheck
+        # No need to require embedded fields from selector expression.
+        text: "QF1008"
+      - linters:
+          - staticcheck
+        # Whether or not to apply De Morgan's law is contextual.
+        text: "QF1001"
+      - linters:
+          - gosec
+        # G304: reading user-specified config/secret files is expected behavior.
+        path: appext/appext.go
+        text: "G304:"
+      - linters:
+          - gosec
+        # G301: 0755 is appropriate for application config directories.
+        path: appext/appext.go
+        text: "G301:"
+      - linters:
+          - unparam
+        path: appext/name_container_unix_test.go
+      - linters:
+          - varnamelen
+        path: app.go
+      - linters:
+          - varnamelen
+        path: appext/builder.go

--- a/Makefile
+++ b/Makefile
@@ -9,14 +9,15 @@ MAKEFLAGS += --no-print-directory
 BIN := .tmp/bin
 export PATH := $(abspath $(BIN)):$(PATH)
 export GOBIN := $(abspath $(BIN))
-COPYRIGHT_YEARS := 2025
+COPYRIGHT_YEARS := 2025-2026
 LICENSE_IGNORE := --ignore testdata/
 
-BUF_VERSION := v1.53.0
-GO_MOD_GOTOOLCHAIN := go1.24.3
-GOLANGCI_LINT_VERSION := v1.64.8
-# https://github.com/golangci/golangci-lint/issues/4837
-GOLANGCI_LINT_GOTOOLCHAIN := $(GO_MOD_GOTOOLCHAIN)
+# https://github.com/bufbuild/buf/releases
+BUF_VERSION := v1.66.1
+GOLANGCI_LINT_VERSION := v2.9.0
+# This version is the go toolchain version (which may be more specific than the module
+# version) to ensure the build handles specific language features in newer toolchains.
+GOLANGCILINT_GOTOOLCHAIN_VERSION := $(shell go env GOVERSION | sed 's/^go//')
 #GO_GET_PKGS :=
 
 .PHONY: help
@@ -48,11 +49,11 @@ install: ## Install all binaries
 .PHONY: lint
 lint: $(BIN)/golangci-lint ## Lint
 	go vet ./...
-	GOTOOLCHAIN=$(GOLANGCI_LINT_GOTOOLCHAIN) golangci-lint run --modules-download-mode=readonly --timeout=3m0s
+	GOTOOLCHAIN=go$(GOLANGCILINT_GOTOOLCHAIN_VERSION) golangci-lint run --modules-download-mode=readonly --timeout=3m0s
 
 .PHONY: lintfix
 lintfix: $(BIN)/golangci-lint ## Automatically fix some lint errors
-	GOTOOLCHAIN=$(GOLANGCI_LINT_GOTOOLCHAIN) golangci-lint run --fix --modules-download-mode=readonly --timeout=3m0s
+	GOTOOLCHAIN=go$(GOLANGCILINT_GOTOOLCHAIN_VERSION) golangci-lint run --fix --modules-download-mode=readonly --timeout=3m0s
 
 .PHONY: generate
 generate: $(BIN)/license-header ## Regenerate code and licenses
@@ -78,4 +79,4 @@ $(BIN)/license-header: Makefile
 
 $(BIN)/golangci-lint: Makefile
 	@mkdir -p $(@D)
-	GOTOOLCHAIN=$(GOLANGCI_LINT_GOTOOLCHAIN) go install github.com/golangci/golangci-lint/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)
+	GOTOOLCHAIN=go$(GOLANGCILINT_GOTOOLCHAIN_VERSION) go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@$(GOLANGCI_LINT_VERSION)

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ generate: $(BIN)/license-header ## Regenerate code and licenses
 
 .PHONY: upgrade
 upgrade: ## Upgrade dependencies
-	go mod edit -toolchain=$(GO_MOD_GOTOOLCHAIN)
 	go get -u -t ./... $(GO_GET_PKGS)
 	go mod tidy -v
 

--- a/app.go
+++ b/app.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/app_error.go
+++ b/app_error.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/app_test.go
+++ b/app_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/app_unix.go
+++ b/app_unix.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/app_windows.go
+++ b/app_windows.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appcmd/appcmd.go
+++ b/appcmd/appcmd.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -330,9 +330,9 @@ func commandToCobra(
 		cobraCommand.Run = func(_ *cobra.Command, args []string) {
 			printUsage(container, cobraCommand.UsageString())
 			if len(args) == 0 {
-				*runErrAddr = errors.New("Sub-command required.")
+				*runErrAddr = errors.New("sub-command required")
 			} else {
-				*runErrAddr = fmt.Errorf("Unknown sub-command: %s", strings.Join(args, " "))
+				*runErrAddr = fmt.Errorf("unknown sub-command: %s", strings.Join(args, " "))
 			}
 		}
 		for _, subCommand := range command.SubCommands {

--- a/appcmd/appcmd.go
+++ b/appcmd/appcmd.go
@@ -330,9 +330,9 @@ func commandToCobra(
 		cobraCommand.Run = func(_ *cobra.Command, args []string) {
 			printUsage(container, cobraCommand.UsageString())
 			if len(args) == 0 {
-				*runErrAddr = errors.New("sub-command required")
+				*runErrAddr = errors.New("Sub-command required")
 			} else {
-				*runErrAddr = fmt.Errorf("unknown sub-command: %s", strings.Join(args, " "))
+				*runErrAddr = fmt.Errorf("Unknown sub-command: %s", strings.Join(args, " "))
 			}
 		}
 		for _, subCommand := range command.SubCommands {

--- a/appcmd/appcmd_test.go
+++ b/appcmd/appcmd_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appcmd/appcmdtesting/appcmdtesting.go
+++ b/appcmd/appcmdtesting/appcmdtesting.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -176,7 +176,7 @@ func WithStdout(stdout io.Writer) RunOption {
 	}
 }
 
-// WithStdout will attach the given stderr to write to.
+// WithStderr will attach the given stderr to write to.
 func WithStderr(stderr io.Writer) RunOption {
 	return func(runOptions *runOptions) {
 		runOptions.stderr = stderr
@@ -200,7 +200,7 @@ func WithExpectedStdout(expectedStdout string) RunOption {
 	}
 }
 
-// WithExpectedStdout will result in an error if the stderr does not exactly equal the given string.
+// WithExpectedStderr will result in an error if the stderr does not exactly equal the given string.
 //
 // Note that this can be called with empty, which will result in Run verifying that the stderr is empty.
 func WithExpectedStderr(expectedStderr string) RunOption {

--- a/appcmd/cobra.go
+++ b/appcmd/cobra.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appcmd/invalid_argument_error.go
+++ b/appcmd/invalid_argument_error.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appcmd/positional_args.go
+++ b/appcmd/positional_args.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/appext.go
+++ b/appext/appext.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/builder.go
+++ b/appext/builder.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/container.go
+++ b/appext/container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/log_format.go
+++ b/appext/log_format.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/log_format_container.go
+++ b/appext/log_format_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/log_level.go
+++ b/appext/log_level.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/log_level_container.go
+++ b/appext/log_level_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/logger_container.go
+++ b/appext/logger_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/name_container.go
+++ b/appext/name_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/appext/name_container_unix_test.go
+++ b/appext/name_container_unix_test.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/arg_container.go
+++ b/arg_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/container.go
+++ b/container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/discard_reader.go
+++ b/discard_reader.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/env_container.go
+++ b/env_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module buf.build/go/app
 
-go 1.23.0
-
-toolchain go1.24.3
+go 1.25.0
 
 require (
 	buf.build/go/interrupt v1.1.0

--- a/locked_writer.go
+++ b/locked_writer.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/stderr_container.go
+++ b/stderr_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/stdin_container.go
+++ b/stdin_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/stdout_container.go
+++ b/stdout_container.go
@@ -1,4 +1,4 @@
-// Copyright 2025 Buf Technologies, Inc.
+// Copyright 2025-2026 Buf Technologies, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
Follow up to #5. This upgrades:

* `buf` to latest
* `golangci-lint` to match buf's version, up to v2
  * Fixes some minor lints
* go.mod version to 1.25.0 (n-1)
* Add 2026 to copyright years