### PR TITLE
Add `LogFormatContainer` and `LogLevelContainer` for exposing the configured `LogFormat` and `LogLevel`

### DIFF
--- a/appext/appext.go
+++ b/appext/appext.go
@@ -91,8 +91,9 @@ func NewLoggerContainer(logger *slog.Logger) LoggerContainer {
 	return newLoggerContainer(logger)
 }
 
-// LogFormatContainer provides the [LogFormat] set for the [Container].
+// LogFormatContainer provides the LogFormat set for the Container.
 type LogFormatContainer interface {
+	// LogFormat returns the LogFormat configured for the Container.
 	LogFormat() LogFormat
 }
 

--- a/appext/appext.go
+++ b/appext/appext.go
@@ -81,7 +81,7 @@ func NewNameContainer(baseContainer app.Container, appName string) (NameContaine
 	return newNameContainer(baseContainer, appName)
 }
 
-// LoggerContainer provides a *slog.Logger.
+// LoggerContainer provides the *slog.Logger set for the Container.
 type LoggerContainer interface {
 	Logger() *slog.Logger
 }
@@ -91,9 +91,18 @@ func NewLoggerContainer(logger *slog.Logger) LoggerContainer {
 	return newLoggerContainer(logger)
 }
 
+// LogLevelContainer provides the LogLevel set for the Container.
+type LogLevelContainer interface {
+	LogLevel() LogLevel
+}
+
+// NewLogLevelContainer returns a new LogLevelContainer.
+func NewLogLevelContainer(logLevel LogLevel) LogLevelContainer {
+	return newLogLevelContainer(logLevel)
+}
+
 // LogFormatContainer provides the LogFormat set for the Container.
 type LogFormatContainer interface {
-	// LogFormat returns the LogFormat configured for the Container.
 	LogFormat() LogFormat
 }
 
@@ -106,6 +115,7 @@ func NewLogFormatContainer(logFormat LogFormat) LogFormatContainer {
 type Container interface {
 	NameContainer
 	LoggerContainer
+	LogLevelContainer
 	LogFormatContainer
 }
 
@@ -113,11 +123,13 @@ type Container interface {
 func NewContainer(
 	nameContainer NameContainer,
 	logger *slog.Logger,
+	logLevel LogLevel,
 	logFormat LogFormat,
 ) Container {
 	return newContainer(
 		nameContainer,
 		logger,
+		logLevel,
 		logFormat,
 	)
 }

--- a/appext/appext.go
+++ b/appext/appext.go
@@ -91,20 +91,33 @@ func NewLoggerContainer(logger *slog.Logger) LoggerContainer {
 	return newLoggerContainer(logger)
 }
 
+// LogFormatContainer provides the [LogFormat] set for the [Container].
+type LogFormatContainer interface {
+	LogFormat() LogFormat
+}
+
+// NewLogFormatContainer returns a new LogFormatContainer.
+func NewLogFormatContainer(logFormat LogFormat) LogFormatContainer {
+	return newLogFormatContainer(logFormat)
+}
+
 // Container contains not just the base app container, but all extended containers.
 type Container interface {
 	NameContainer
 	LoggerContainer
+	LogFormatContainer
 }
 
 // NewContainer returns a new Container.
 func NewContainer(
 	nameContainer NameContainer,
 	logger *slog.Logger,
+	logFormat LogFormat,
 ) Container {
 	return newContainer(
 		nameContainer,
 		logger,
+		logFormat,
 	)
 }
 

--- a/appext/builder.go
+++ b/appext/builder.go
@@ -102,7 +102,7 @@ func (b *builder) run(
 	if err != nil {
 		return err
 	}
-	container := newContainer(nameContainer, logger)
+	container := newContainer(nameContainer, logger, logFormat)
 
 	var cancel context.CancelFunc
 	if b.timeout != 0 {

--- a/appext/builder.go
+++ b/appext/builder.go
@@ -102,7 +102,7 @@ func (b *builder) run(
 	if err != nil {
 		return err
 	}
-	container := newContainer(nameContainer, logger, logFormat)
+	container := newContainer(nameContainer, logger, logLevel, logFormat)
 
 	var cancel context.CancelFunc
 	if b.timeout != 0 {

--- a/appext/log_format_container.go
+++ b/appext/log_format_container.go
@@ -14,24 +14,16 @@
 
 package appext
 
-import (
-	"log/slog"
-)
-
-type container struct {
-	NameContainer
-	LoggerContainer
-	LogFormatContainer
+type logFormatContainer struct {
+	logFormat LogFormat
 }
 
-func newContainer(
-	nameContainer NameContainer,
-	logger *slog.Logger,
-	logFormat LogFormat,
-) *container {
-	return &container{
-		NameContainer:      nameContainer,
-		LoggerContainer:    newLoggerContainer(logger),
-		LogFormatContainer: newLogFormatContainer(logFormat),
+func newLogFormatContainer(logFormat LogFormat) *logFormatContainer {
+	return &logFormatContainer{
+		logFormat: logFormat,
 	}
+}
+
+func (c *logFormatContainer) LogFormat() LogFormat {
+	return c.logFormat
 }

--- a/appext/log_level_container.go
+++ b/appext/log_level_container.go
@@ -14,27 +14,16 @@
 
 package appext
 
-import (
-	"log/slog"
-)
-
-type container struct {
-	NameContainer
-	LoggerContainer
-	LogLevelContainer
-	LogFormatContainer
+type logLevelContainer struct {
+	logLevel LogLevel
 }
 
-func newContainer(
-	nameContainer NameContainer,
-	logger *slog.Logger,
-	logLevel LogLevel,
-	logFormat LogFormat,
-) *container {
-	return &container{
-		NameContainer:      nameContainer,
-		LoggerContainer:    newLoggerContainer(logger),
-		LogLevelContainer:  newLogLevelContainer(logLevel),
-		LogFormatContainer: newLogFormatContainer(logFormat),
+func newLogLevelContainer(logLevel LogLevel) *logLevelContainer {
+	return &logLevelContainer{
+		logLevel: logLevel,
 	}
+}
+
+func (c *logLevelContainer) LogLevel() LogLevel {
+	return c.logLevel
 }


### PR DESCRIPTION
This adds a `LogFormatContainer` to `Container` that exposes
the `LogFormat` configured to the container. This allows output
that is rendered outside of the `Logger` to use the same configs,
e.g. `color`.